### PR TITLE
Expand toxicity score and provide some AI supported postman test cases

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Regenerate Postman Collection",
+      "type": "shell",
+      "command": "python scripts/generate_postman_collection.py",
+      "group": "build",
+      "presentation": {
+        "reveal": "always"
+      }
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # I haven't tested but we may need a different base image for anything that can't run CUDA (CPU only)
 FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
 
-WORKDIR /app
+WORKDIR /dcc
 
 # Install Python and system dependencies + clean up
 RUN apt update && apt install -y python3-pip python3-dev git \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ build:
 models:
 	docker compose run --rm --no-deps api python3 app/load_models.py
 
+dev:
+	docker compose run --rm -p $(PORT):$(PORT) api uvicorn app.main:app --reload --host 0.0.0.0 --port $(PORT) --reload-dir /dcc/app
+
 up:
 	docker compose up -d
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ make build && make models
 ```
 
 Build will take a long time, about 15-20 minutes.
-- Build mostly takes time when downloading and building torch. Would take about `[+] Building 736.5s (14/14) FINISHED ` in my case.
+- Build mostly takes time when downloading and building torch. Would take about `[+] Building 851.8s (14/14) FINISHED` in my case.
 - Downloading the models for the classifiers takes another 5 or so minutes
 
 Once built and models downloaded, run the thing:

--- a/app/comment_processor.py
+++ b/app/comment_processor.py
@@ -1,8 +1,10 @@
-from .load_models import get_models
+from .load_models import get_spam_detection_model, get_toxicity_detection_model, get_translation_model
 
 def screen_comment(comment):
-    translator, spam_detector, toxicity_detector = get_models()
-    translation = translator(comment)[0]['translation_text']
+    spam_detector = get_spam_detection_model()
+    toxicity_detector = get_toxicity_detection_model()
+    translation = translate_text(comment)
+
     spam_result = spam_detector(translation)[0]
     toxicity_result = toxicity_detector(translation)[0]
 
@@ -10,11 +12,13 @@ def screen_comment(comment):
         "original": comment,
         "translated": translation,
         "spam": {
-            "label": spam_result['label'],
+            "label": spam_result['label'], # we only need either spam or ham, not both
             "score": spam_result['score'],
         },
-        "toxicity": {
-            "label": toxicity_result['label'],
-            "score": toxicity_result['score'],
-        }
+        "toxicity": toxicity_result # This one we want everything to compare it with perspective API later
     }
+
+def translate_text(str):
+    translator = get_translation_model()
+    translation = translator(str)[0]['translation_text']
+    return translation

--- a/app/load_models.py
+++ b/app/load_models.py
@@ -1,14 +1,37 @@
-from transformers import pipeline
-import logging
-from functools import lru_cache
-
 # My first iteration was using Ollama and relying only on prompt engineering (You are a spam detector blah blah blah ...).
 # This time we'll try using huggingfaces' existing models for translation, spam detection, and toxicity detection.
 # This way we can simulate production "cheap first - smart later" approach.
 # The plan is to let these do the initial processing first, ideally 90% of the time,
 # and only escalate to a more expensive model when necessary.
+
+from transformers import pipeline, AutoTokenizer, AutoModelForSequenceClassification, TextClassificationPipeline
+import logging
+from functools import lru_cache
+
 @lru_cache(maxsize=1)
-def get_models(verbose=False):
+def get_translation_model():
+    return pipeline("translation", model="Helsinki-NLP/opus-mt-nl-en")
+
+@lru_cache(maxsize=1)
+def get_spam_detection_model():
+    return pipeline("text-classification", model="valurank/distilroberta-spam-comments-detection")
+
+@lru_cache(maxsize=1)
+def get_toxicity_detection_model():
+    model_name = "unitary/toxic-bert"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForSequenceClassification.from_pretrained(model_name)
+
+    return TextClassificationPipeline(
+        model=model,
+        tokenizer=tokenizer,
+        return_all_scores=True,
+        top_k=None,  # Return everything, not just top-k
+        function_to_apply="sigmoid",  # I think this defaults anyway, but let's be explicit about it
+    )
+
+
+def get_all_models(verbose=False):
     if verbose:
         logging.basicConfig(level=logging.INFO)
         log = logging.info
@@ -16,19 +39,19 @@ def get_models(verbose=False):
         log = lambda *args, **kwargs: None
 
     log("Downloading/loading translation model...")
-    translator = pipeline("translation", model="Helsinki-NLP/opus-mt-nl-en")
+    translator = get_translation_model()
 
     log("Downloading/loading spam detection model...")
-    spam_detector = pipeline("text-classification", model="valurank/distilroberta-spam-comments-detection")
+    spam_detector = get_spam_detection_model()
 
     log("Downloading/loading toxicity detection model...")
-    toxicity_detector = pipeline("text-classification", model="unitary/toxic-bert")
+    toxicity_detector = get_toxicity_detection_model()
 
     return translator, spam_detector, toxicity_detector
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     logging.info("Starting model download and cache...")
-    get_models(verbose=True)
+    get_all_models(verbose=True)
     logging.info("All models downloaded and cached.")
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,16 @@
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
+from typing import Optional
 from app.comment_processor import screen_comment
 
 app = FastAPI()
 
-class CommentRequest(BaseModel):
-    comment: str = Field(..., example="Je bent dom")
+class CommentRequest(BaseModel):    
+    subject: str = Field(..., example="De overheid heeft aangekondigd dat de btw volgend jaar wordt verhoogd.")
+    context: Optional[str] = Field(None, example="Ik ben het er niet mee eens.")
+    comment: str = Field(..., example="Je begrijpt er echt niets van.")
 
-@app.post("/check")
+@app.post("/api/v1/check_comment")
 async def check_comment(request: CommentRequest):
     result = screen_comment(request.comment)
     return result

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,13 @@ services:
       - "${API_PORT:-8000}:8000"
     volumes:
       - ${HF_CACHE_PATH:-./hf_cache}:/root/.cache/huggingface
+      - ./app:/dcc/app
     environment:
       - HF_HOME=/root/.cache/huggingface
     depends_on:
       - dcc_ollama
     restart: unless-stopped
+    working_dir: /dcc
     # Prevents that pesky Downloading torch-2.7.1-cp310-cp310-manylinux_2_28_x86_64.whl (821.2 MB)
     # Which pretty much takes forever to build
     # This should ensure we'll be working with the GPU version
@@ -30,3 +32,10 @@ services:
     ports:
       - "${OLLAMA_PORT:-11434}:11434"
     restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/postman_dcc_collection.json
+++ b/postman_dcc_collection.json
@@ -1,0 +1,73 @@
+{
+  "info": {
+    "name": "Dutch Comments Checker",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Check Comment",
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"subject\": \"Voorbeeld artikel titel\",\n  \"context\": \"Voorbeeld context of paragraaf\",\n  \"comment\": \"Voorbeeld commentaar, kan normaal, spam, toxic, of grijs gebied zijn.\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/v1/check_comment",
+          "host": ["{{base_url}}"],
+          "path": ["api", "v1", "check_comment"]
+        }
+      }
+    },
+    {
+      "name": "Check Comment Auto Test",
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"subject\": \"{{subject}}\",\n  \"context\": \"{{context}}\",\n  \"comment\": \"{{comment}}\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/v1/check_comment",
+          "host": ["{{base_url}}"],
+          "path": ["api", "v1", "check_comment"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const expectedHam = Number(pm.iterationData.get('ham'));",
+              "const expectedSpam = Number(pm.iterationData.get('spam'));",
+              "const expectedToxic = Number(pm.iterationData.get('toxic'));",
+              "const res = pm.response.json();",
+              "const actualHam = res.spam && res.spam.label === 'ham' ? res.spam.score : 0;",
+              "const actualSpam = res.spam && res.spam.label === 'spam' ? res.spam.score : 0;",
+              "const actualToxic = Array.isArray(res.toxicity) ? (res.toxicity.find(t => t.label === 'toxic')?.score || 0) : 0;",
+              "if (expectedHam > 0) {",
+              "    pm.test('Ham score should be >= expected', function () {",
+              "        pm.expect(actualHam).to.be.at.least(expectedHam);",
+              "    });",
+              "}",
+              "if (expectedSpam > 0) {",
+              "    pm.test('Spam score should be >= expected', function () {",
+              "        pm.expect(actualSpam).to.be.at.least(expectedSpam);",
+              "    });",
+              "}",
+              "if (expectedToxic > 0) {",
+              "    pm.test(`Toxic score (${actualToxic}) should be >= expected (${expectedToxic})`, function () {",
+              "        pm.expect(actualToxic).to.be.at.least(expectedToxic);",
+              "    });",
+              "}"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    }
+  ],
+  "event": []
+}

--- a/postman_dcc_collection.md
+++ b/postman_dcc_collection.md
@@ -1,0 +1,44 @@
+# Postman Test Runner Maintenance Instructions
+
+You are an agent that maintains a CSV file of test cases for the Dutch Comments Checker API.
+
+## Instructions
+
+- Read `app/main.py` for all endpoints except `/openapi.json`.
+- For `/api/v1/check_comment`, generate a CSV file named `postman_dcc_collection_examples.csv` with the following columns:
+  - `subject`
+  - `context`
+  - `comment`
+  - `ham`
+  - `spam`
+  - `toxic`
+- Each row should be a realistic Dutch example, covering:
+  - Deliberate spam comments
+  - Deliberate toxic comments
+  - Grey area comments
+  - Normal comments
+  - Sarcastic, heated, or problematic comments (not actual spam or toxic)
+- Use a variety of topics (e.g., football, news, betting, etc.).
+- For each example, provide expected scores for `ham`, `spam`, and `toxic` columns. Use float values (e.g., 0.7) or `0` if not applicable. For instance, a normal comment might have `ham: 0.7`, `spam: 0`, `toxic: 0`. While a spam will have `ham: 0`, `spam: 0.7`, `toxic: 0` and a toxic can be `ham: 0`, `spam: 0.5` (as it will likely be tagged spam too, but we'll be lenient at 0.5), `toxic: 0.7`.
+- Update the CSV whenever endpoints or logic change.
+
+## Example CSV Format
+
+subject,context,comment,ham,spam,toxic
+"Ajax verliest opnieuw in de Eredivisie","Ajax speelde erg slecht deze wedstrijd.","Je hebt duidelijk geen verstand van voetbal.",0.1,null,0.9
+"Live goals en uitslagen","Bekijk hier de hoogtepunten van de wedstrijden.","Dit moet je zien: http://bit.ly/live-goals",null,0.9,null
+"Feyenoord wint overtuigend van PSV","Wat een geweldige goal van Til!","Goed gespeeld vandaag, verdiende overwinning.",0.9,null,null
+"Insider tips voor weddenschappen","Word lid van onze voetbal insiders groep.","Word lid op Telegram: t.me/voetbalwinnaars",null,0.8,null
+"KNVB maakt nieuwe speelschema's bekend","De wedstrijden zijn te dicht op elkaar gepland.","Typisch weer een dom besluit van de KNVB.",null,null,0.8
+
+## Expected Output
+
+- Your examples should be comprehensive and complete
+- Cover possible case scenarios, like
+  - A comment is a normal comment
+  - A comment is toxic
+  - A comment is spam
+  - A comment is heated, sarcastic, but not toxic. Basically grey area
+  - and so on
+- Decide how best an endpoint should be tested and reflect that in the CSV examples
+- Include edge cases and ambiguous comments to test model boundaries

--- a/postman_dcc_examples.csv
+++ b/postman_dcc_examples.csv
@@ -1,0 +1,15 @@
+subject,context,comment,ham,spam,toxic
+"Ajax verliest opnieuw in de Eredivisie","Ajax speelde erg slecht deze wedstrijd.","Je hebt duidelijk geen verstand van voetbal.",0.1,0,0
+"Live goals en uitslagen","Bekijk hier de hoogtepunten van de wedstrijden.","Dit moet je zien: http://bit.ly/live-goals",0,0.7,0
+"Feyenoord wint overtuigend van PSV","Wat een geweldige goal van Til!","Goed gespeeld vandaag, verdiende overwinning.",0.7,0,0
+"Insider tips voor weddenschappen","Word lid van onze voetbal insiders groep.","Word lid op Telegram: t.me/voetbalwinnaars",0,0.7,0
+"KNVB maakt nieuwe speelschema's bekend","De wedstrijden zijn te dicht op elkaar gepland.","Typisch weer een dom besluit van de KNVB.",0.7,0,0
+"Discussie over verhoging van de btw","Sommige economen steunen de maatregel, anderen zijn kritisch.","Dit is echt een belachelijk idee, het zal alleen maar problemen veroorzaken!",0.7,0,0
+"Kabinet presenteert nieuwe plannen voor zorg","De plannen moeten de zorg betaalbaar houden.","Ja hoor, dat zal vast werken... net als de vorige keer!",0.7,0,0
+"Nederland investeert in groene energie","De overheid trekt 2 miljard euro uit voor wind- en zonne-energie.","Goed initiatief, hopelijk levert het echt iets op.",0.7,0,0
+"Nieuwe maatregelen tegen klimaatverandering aangekondigd","Ik geloof niet dat deze maatregelen echt gaan helpen.","Je mag best wat positiever zijn, het is een stap in de goede richting.",0.7,0,0
+"Kabinet wil investeren in onderwijs",,"Goed plan! Onderwijs verdient meer aandacht.",0.7,0,0
+"Spam met obvious link",,"Verdien €500 per dag vanuit huis! Meld je nu aan op onze website: www.snelgeld123.nl",0,0.7,0
+"Directe belediging","","Wat ben jij een achterlijke klootzak, rot op van dit forum.",0,0,0.7
+"Sarcastische opmerking over voetbal","Ajax speelde niet best.","Altijd hetzelfde met Ajax, groot praten maar niks presteren.",0.7,0,0
+"Ambigue comment","Soms is het lastig te bepalen of iets kwetsend is.","Dat was een interessante discussie, sommige mensen zijn wel erg direct.",0.7,0,0

--- a/requirements.docker.txt
+++ b/requirements.docker.txt
@@ -4,7 +4,7 @@ uvicorn
 
 # LLM Dependencies
 transformers
-# torch is intentionally omitted for Docker GPU builds
+# Dockercompose will handle torch manually, otherwise it can't detect GPU
 
 # Translation
 sentencepiece

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn
 
 # LLM Dependencies
 transformers
-torch==2.7.1 # so prebuilds will work (for local/dev only)
+torch
 
 # Translation
 sentencepiece


### PR DESCRIPTION
# Summary

- Expand toxicity score to other metrics like insult, obscenity, hate, threat.
- Add postman export and some test cases as our trusted seed (manually modified already)

# Known Issues

We can't entirely depend on what's commanded in `postman_dcc_collection.md`. The thing sometimes mark non toxic things as toxic and vice versa. Copilot is not as accurate here as the actual transformers. So we'll need to actually test and tweak each test values to see if there's any false negatives.